### PR TITLE
Add duplicate project button

### DIFF
--- a/apps/web/app/(dashboard)/projects/page.tsx
+++ b/apps/web/app/(dashboard)/projects/page.tsx
@@ -171,7 +171,7 @@ export default function ProjectsPage() {
                 transition={{ duration: 0.3, delay: index * 0.05 }}
                 layout
               >
-                <ProjectCard project={project} onProjectDeleted={refresh} />
+                <ProjectCard project={project} allProjects={projects} onProjectDeleted={refresh} onProjectDuplicated={refresh} />
               </motion.div>
             ))}
           </AnimatePresence>


### PR DESCRIPTION
## Summary
- Adds a "Duplicate" option to the project card's 3-dot dropdown menu
- Creates a copy of the project with all settings (frequency, schedule, search parameters, project settings)
- Appends "(Copy)" to the title, incrementing to "(Copy 2)", "(Copy 3)" etc. if duplicates already exist
- Shows a progress dialog with spinner while duplicating and a success confirmation when complete
- Respects active project limits — shows the paused info dialog when the user has too many active projects

## Test plan
- [ ] Click 3-dot menu on a project card → verify "Duplicate" option appears between "Run Now" and "Delete"
- [ ] Click Duplicate → verify progress dialog appears with spinner
- [ ] After success → verify success dialog with checkmark appears briefly, then the new project card shows in the list
- [ ] Duplicate a project that was already duplicated → verify title increments ("Copy 2", "Copy 3", etc.)
- [ ] Duplicate when at active project limit → verify paused info dialog appears after the success dialog
- [ ] Verify all project settings are copied (frequency, schedule, search params, advanced settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)